### PR TITLE
ローカルサーバ起動用に Makefile を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# -*- makefile -*-
+
+PORT_NUMBER = 5080
+
+usage:
+	@echo "Usage:"
+	@echo "  make server"
+
+server:
+	@echo "Starting server..."
+	php -S 0.0.0.0:$(PORT_NUMBER)


### PR DESCRIPTION
Codespaces で開発をする際に確認しやすいよう、HTML 確認用のローカルサーバを起動する Makefile を追加。

```
make server
```

とすることで、Codespaces に入っている php-cli によってローカルサーバを 5080 番ポートで起動する。